### PR TITLE
Handle systems with non-existent sensors.

### DIFF
--- a/biteback/modules/temperature.py
+++ b/biteback/modules/temperature.py
@@ -16,9 +16,14 @@ class Temperature(module.BasicModule):
     final   = TempFinal()
 
     def run(self):
-        temp = float(shell("/etc/munin/plugins/temp").split(" ")[1])
-        if temp > 100.0:
-            return False
+        temp = shell("/etc/munin/plugins/temp").split(" ")[1]
+        if len(temp) > 0 and temp[0].isdigit():
+            # only convert if temp has at least a digit
+            temp = float(shell("/etc/munin/plugins/temp").split(" ")[1])
+            if temp > 100.0:
+                return False 
+        
+        # for vm environments without sensors, temp is empty/non-digit so return True for these cases.  
         return True
 
 register.put(Temperature())

--- a/biteback/modules/temperature.py
+++ b/biteback/modules/temperature.py
@@ -18,12 +18,12 @@ class Temperature(module.BasicModule):
     def run(self):
         temp = shell("/etc/munin/plugins/temp").split(" ")[1]
         if len(temp) > 0 and temp[0].isdigit():
-            # only convert if temp has at least a digit
-            temp = float(shell("/etc/munin/plugins/temp").split(" ")[1])
-            if temp > 100.0:
+            # only convert if temp has at least a digit            
+            if float(temp) > 100.0:
                 return False 
         
-        # for vm environments without sensors, temp is empty/non-digit so return True for these cases.  
+        # Temp is either below max threshold, or in a virtual environment (e.g. qemu)
+        # without sensors (temp is empty/non-digit). All good.   
         return True
 
 register.put(Temperature())


### PR DESCRIPTION
In virtual environments, sensors may not be available (e.g. qemu, "sensors -u" and "sensors-detect" show zero found sensors; but other vms may expose the system sensors of course).

This results in non-digit output (typically empty string), so this patch checks if the sensor output is a non-zero string, and if so, it must start with a digit to try conversion.

Alternatively, we could just have try/except to catch the float() parse error.

Only tested in vm - should also be tested on real node (e.g. change 100 to 10 and check that it correctly goes to maintenance)